### PR TITLE
hopefully fix problem with top level home-link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo version; hugo mod get; hugo --minify;"
 
 [build.environment]
-HUGO_VERSION = "0.99.1"
+HUGO_VERSION = "0.111.3"
 
 [context.deploy-preview]
 command = "hugo version; hugo mod get; hugo --minify -b $DEPLOY_PRIME_URL;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
 publish = "public"
-command = "hugo version; hugo mod get; hugo --minify -b $DEPLOY_PRIME_URL;"
+command = "hugo version; hugo mod get; hugo --minify --baseURL $DEPLOY_PRIME_URL;"
 
 [build.environment]
 HUGO_VERSION = "0.111.3"
 
 [context.deploy-preview]
-command = "hugo version; hugo mod get; hugo --minify -b $DEPLOY_PRIME_URL;"
+command = "hugo version; hugo mod get; hugo --minify --baseURL $DEPLOY_PRIME_URL;"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo version; hugo mod get; hugo --minify;"
+command = "hugo version; hugo mod get; hugo --minify -b $DEPLOY_PRIME_URL;"
 
 [build.environment]
 HUGO_VERSION = "0.111.3"


### PR DESCRIPTION
OK, so I think this should fix the following problem:

- Go to  https://festiwalswiatla.hs3.pl/en/about-us/
- Switch to EN
- Go to "Organisation" in top level
- Click the top-left logo (should send you back to home, will send you to 404).
This seems to be because the baseURL is not set on live.

The irritating thing is that it is set on PR preview domain, so we cannot test this without putting it live.

However maybe someone explicitly decided not to do this on live, in which case I don't want to break it all.

(Also I'm not 100% sure this will fix it)